### PR TITLE
CFE-1980: Add email notification configuration to provider

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -24,8 +24,9 @@ resource "identity_platform_config" "auth_config" {
   }
 
   notification {
-    sendEmail {
-      callbackUri = "https://test-callback-uri.co"
+    send_email {
+      method = "default"
+      callback_uri = "https://<gcp-project-id>.firebaseapp.com/__/auth/action"
     }
   }
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -23,6 +23,12 @@ resource "identity_platform_config" "auth_config" {
     enabled = true
   }
 
+  notification {
+    sendEmail {
+      callbackUri = "https://test-callback-uri.co"
+    }
+  }
+
   subtype = "IDENTITY_PLATFORM"
 
   authorized_domains = [

--- a/identity_platform/resource_config.go
+++ b/identity_platform/resource_config.go
@@ -50,13 +50,18 @@ func resourceConfig() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"sendEmail": {
+						"send_email": {
 							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"callbackUri": {
+									"method": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  "default",
+									},
+									"callback_uri": {
 										Type:     schema.TypeString,
 										Optional: true,
 										Default:  true,
@@ -165,7 +170,7 @@ func configFromResourceData(d *schema.ResourceData) (string, *idp.Config) {
 	authorizedDomains := d.Get("authorized_domains").([]interface{})
 	notification := d.Get("notification").([]interface{})
 
-	sendEmail := extractProperties(notification)["sendEmail"].([]interface{})
+	sendEmail := extractProperties(notification)["send_email"].([]interface{})
 
 	config := &idp.Config{
 		SignIn: &idp.SignInConfig{
@@ -179,7 +184,8 @@ func configFromResourceData(d *schema.ResourceData) (string, *idp.Config) {
 		},
 		Notification: &idp.NotificationConfig{
 			SendEmail: &idp.SendEmail{
-				CallbackUri: extractProperties(sendEmail)["callbackUri"].(string),
+				Method:      extractProperties(sendEmail)["method"].(string),
+				CallbackUri: extractProperties(sendEmail)["callback_uri"].(string),
 			},
 		},
 		Subtype:           subtype,
@@ -221,8 +227,9 @@ func hydrate(diags diag.Diagnostics, config *idp.Config, d *schema.ResourceData)
 
 	arr = TerraformListType{
 		{
-			"sendEmail": Object{
-				"callbackUri": config.Notification.SendEmail.CallbackUri,
+			"send_email": Object{
+				"method": config.Notification.SendEmail.Method,
+				"callback_uri": config.Notification.SendEmail.CallbackUri,
 			},
 		},
 	}

--- a/identity_platform/resource_config.go
+++ b/identity_platform/resource_config.go
@@ -9,7 +9,6 @@ import (
 
 type Object map[string]interface{}
 type TerraformListType []Object
-type TerraformObjectType Object
 
 func resourceConfig() *schema.Resource {
 	return &schema.Resource{

--- a/identity_platform/resource_config.go
+++ b/identity_platform/resource_config.go
@@ -222,7 +222,7 @@ func hydrate(diags diag.Diagnostics, config *idp.Config, d *schema.ResourceData)
 
 	arr = TerraformListType{
 		{
-			"sendEmail": TerraformObjectType{
+			"sendEmail": Object{
 				"callbackUri": config.Notification.SendEmail.CallbackUri,
 			},
 		},


### PR DESCRIPTION
## Scope
We are needing to allow for the callback URI to be set for email notifications.

## Work Done
1. Update the schema to allow for the callback URI to be set.
2. Update the hydrate function to retrieve the appropriate values from memory.
3. Update the request data with the retrieve value from the Terraform resource.
4. Added method to the schema because it's required.